### PR TITLE
Fix `createTx` of some networks

### DIFF
--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -233,6 +233,13 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
       throw new CurrencyNotFound(token);
     }
 
+    const useNewDestWeight =
+      this.api.tx.xTokens.transfer.meta.args[3].type.toString() ===
+      "XcmV2WeightLimit";
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const oldDestWeight = this.getDestWeight(token, to)!.toString();
+    const destWeight = useNewDestWeight ? "Unlimited" : oldDestWeight;
+
     return this.api.tx.xTokens.transfer(
       tokenId,
       amount.toChainData(),
@@ -248,7 +255,7 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
         },
       },
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.getDestWeight(token, to)!.toString()
+      destWeight
     );
   }
 }

--- a/src/adapters/integritee.ts
+++ b/src/adapters/integritee.ts
@@ -156,6 +156,13 @@ class BaseIntegriteeAdapter extends BaseCrossChainAdapter {
 
     const accountId = this.api?.createType("AccountId32", address).toHex();
 
+    const useNewDestWeight =
+      this.api.tx.xTokens.transfer.meta.args[3].type.toString() ===
+      "XcmV2WeightLimit";
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const oldDestWeight = this.getDestWeight(token, to)!.toString();
+    const destWeight = useNewDestWeight ? "Unlimited" : oldDestWeight;
+
     return this.api?.tx.xTokens.transfer(
       token,
       amount.toChainData(),
@@ -171,7 +178,7 @@ class BaseIntegriteeAdapter extends BaseCrossChainAdapter {
         },
       },
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.getDestWeight(token, to)!
+      destWeight
     );
   }
 }

--- a/src/adapters/oak.ts
+++ b/src/adapters/oak.ts
@@ -63,10 +63,10 @@ export const turingTokensConfig: Record<string, BasicToken> = {
 };
 
 const SUPPORTED_TOKENS: Record<string, string> = {
-  TUR: "TUR",
-  KAR: "KAR",
-  KUSD: "AUSD",
-  LKSM: "LKSM",
+  TUR: "0",
+  KAR: "3",
+  KUSD: "2",
+  LKSM: "4",
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -228,7 +228,7 @@ class BaseOakAdapter extends BaseCrossChainAdapter {
     }
 
     return this.api?.tx.xTokens.transfer(
-      token === this.balanceAdapter?.nativeToken ? "Native" : tokenId,
+      token === this.balanceAdapter?.nativeToken ? "0" : tokenId,
       amount.toChainData(),
       {
         V1: {

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -278,6 +278,13 @@ class BaseParallelAdapter extends BaseCrossChainAdapter {
       throw new CurrencyNotFound(token);
     }
 
+    const useNewDestWeight =
+      this.api.tx.xTokens.transfer.meta.args[3].type.toString() ===
+      "XcmV2WeightLimit";
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const oldDestWeight = this.getDestWeight(token, to)!.toString();
+    const destWeight = useNewDestWeight ? "Unlimited" : oldDestWeight;
+
     return this.api.tx.xTokens.transfer(
       tokenId,
       amount.toChainData(),
@@ -293,7 +300,7 @@ class BaseParallelAdapter extends BaseCrossChainAdapter {
         },
       },
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.getDestWeight(token, to)!.toString()
+      destWeight
     );
   }
 }


### PR DESCRIPTION
# Problem
I tested all of the adapters, and found 4 networks that have their `createTx` resulted in error
1. Parallel
2. Bifrost
3. Integritee
4. Turing

1-3 all have same problem, where the chain currently supports `XcmV2WeightLimit`, so using `getDestWeight` results in error
to fix this, I add logic to check if the chain supports `XcmV2WeightLimit`, with pretty much same logic as how acala adapter does it.

Turing have different problem, where now the `tokenId` is represented as number, not strings.
To fix this, I change the `tokenId` to match the current chain state.