### PR TITLE
fix: support the new xtokens interface on interlay/kintsugi

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,3 +51,12 @@ export class NoCrossChainAdapterFound extends Error {
     this.name = "NoCrossChainAdapterFound";
   }
 }
+
+export class DestinationWeightNotFound extends Error {
+  constructor(source: string, destination: string, token: string) {
+    super();
+
+    this.message = `Can't find ${source} addapter's destination weight for ${destination} destination sending ${token} token.`;
+    this.name = "DestinationWeightNotFound";
+  }
+}


### PR DESCRIPTION
The kintsugi network will upgrade soon to a version that does includes https://github.com/open-web3-stack/open-runtime-module-library/pull/841, which changes the type of one of the arguments of `xTokens.transfer`. This PR make it such that both the old and the new versions will be supported.