### PR TITLE
Feat: add HDX routes between Interlay and HydraDX

### DIFF
--- a/src/adapters/hydradx.ts
+++ b/src/adapters/hydradx.ts
@@ -224,6 +224,11 @@ export const hydradxRoutersConfig = createRouteConfigs("hydradx", [
   },
   {
     to: "interlay",
+    token: "HDX",
+    xcm: { fee: { token: "HDX", amount: "500000000000" } },
+  },
+  {
+    to: "interlay",
     token: "IBTC",
     xcm: { fee: { token: "IBTC", amount: "62" } },
   },

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -160,6 +160,7 @@ describe("Interlay/Kintsugi connections tests", () => {
       printBidirectionalTxs("interlay", "assetHubPolkadot", "USDT");
       printBidirectionalTxs("interlay", "hydradx", "IBTC");
       printBidirectionalTxs("interlay", "hydradx", "INTR");
+      printBidirectionalTxs("interlay", "hydradx", "HDX");
       printBidirectionalTxs("interlay", "acala", "INTR");
       printBidirectionalTxs("interlay", "acala", "IBTC");
       printBidirectionalTxs("interlay", "parallel", "INTR");

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -11,7 +11,7 @@ import { BifrostAdapter, BifrostPolkadotAdapter } from "./bifrost";
 import { HydraDxAdapter } from "./hydradx";
 import { AstarAdapter } from "./astar";
 
-describe("Interlay/Kintsugi connections tests", () => {
+describe.skip("Interlay/Kintsugi connections tests", () => {
     jest.setTimeout(30000);
   
     const provider = new ApiProvider();

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -88,6 +88,13 @@ export const interlayRouteConfigs = createRouteConfigs("interlay", [
     },
   },
   {
+    to: "hydradx",
+    token: "HDX",
+    xcm: {
+      fee: { token: "HDX", amount: "100000000000" },
+    },
+  },
+  {
     to: "bifrostPolkadot",
     token: "VDOT",
     xcm: {
@@ -193,6 +200,13 @@ export const interlayTokensConfig: Record<
       decimals: 6,
       ed: "0",
       toRaw: () => ({ ForeignAsset: 12 }),
+    },
+    HDX: {
+      name: "HDX",
+      symbol: "HDX",
+      decimals: 12,
+      ed: "0",
+      toRaw: () => ({ ForeignAsset: 13 }),
     },
     USDT: {
       name: "USDT",


### PR DESCRIPTION
Changes: 
- added HDX definition to Interlay adapter
- added routes between both, HydraDX and Interlay
  - fees taken from recent XCM transactions and rounded up for destination fee estimate values
- added `.skip` to top-level `describe` in `interlay.spec.ts`