### PR TITLE
Feat: Add BNC routes between Bifrost and Interlay

### DIFF
--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -67,6 +67,13 @@ export const bifrostPolkadotRoutersConfig = createRouteConfigs(
         fee: { token: "VDOT", amount: "20000000" },
       },
     },
+    {
+      to: "interlay",
+      token: "BNC",
+      xcm: {
+        fee: { token: "BNC", amount: "50000000000" },
+      },
+    },
   ]
 );
 

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -11,7 +11,7 @@ import { BifrostAdapter, BifrostPolkadotAdapter } from "./bifrost";
 import { HydraDxAdapter } from "./hydradx";
 import { AstarAdapter } from "./astar";
 
-describe("Interlay/Kintsugi connections tests", () => {
+describe.skip("Interlay/Kintsugi connections tests", () => {
     jest.setTimeout(30000);
   
     const provider = new ApiProvider();

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -11,7 +11,7 @@ import { BifrostAdapter, BifrostPolkadotAdapter } from "./bifrost";
 import { HydraDxAdapter } from "./hydradx";
 import { AstarAdapter } from "./astar";
 
-describe("Interlay/Kintsugi connections tests", () => {
+describe.skip("Interlay/Kintsugi connections tests", () => {
     jest.setTimeout(30000);
   
     const provider = new ApiProvider();
@@ -167,6 +167,7 @@ describe("Interlay/Kintsugi connections tests", () => {
       printBidirectionalTxs("interlay", "astar", "INTR");
       printBidirectionalTxs("interlay", "astar", "IBTC");
       printBidirectionalTxs("interlay", "bifrostPolkadot", "VDOT");
+      printBidirectionalTxs("interlay", "bifrostPolkadot", "BNC");
       printBidirectionalTxs("polkadot", "assetHubPolkadot", "DOT");
     });
   

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -167,6 +167,7 @@ describe.skip("Interlay/Kintsugi connections tests", () => {
       printBidirectionalTxs("interlay", "astar", "INTR");
       printBidirectionalTxs("interlay", "astar", "IBTC");
       printBidirectionalTxs("interlay", "bifrostPolkadot", "VDOT");
+      printBidirectionalTxs("interlay", "bifrostPolkadot", "BNC");
       printBidirectionalTxs("polkadot", "assetHubPolkadot", "DOT");
     });
   

--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -11,7 +11,7 @@ import { BifrostAdapter, BifrostPolkadotAdapter } from "./bifrost";
 import { HydraDxAdapter } from "./hydradx";
 import { AstarAdapter } from "./astar";
 
-describe.skip("Interlay/Kintsugi connections tests", () => {
+describe("Interlay/Kintsugi connections tests", () => {
     jest.setTimeout(30000);
   
     const provider = new ApiProvider();
@@ -167,7 +167,6 @@ describe.skip("Interlay/Kintsugi connections tests", () => {
       printBidirectionalTxs("interlay", "astar", "INTR");
       printBidirectionalTxs("interlay", "astar", "IBTC");
       printBidirectionalTxs("interlay", "bifrostPolkadot", "VDOT");
-      printBidirectionalTxs("interlay", "bifrostPolkadot", "BNC");
       printBidirectionalTxs("polkadot", "assetHubPolkadot", "DOT");
     });
   

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -95,6 +95,14 @@ export const interlayRouteConfigs = createRouteConfigs("interlay", [
       weightLimit: DEST_WEIGHT,
     },
   },
+  {
+    to: "bifrostPolkadot",
+    token: "BNC",
+    xcm: {
+      fee: { token: "BNC", amount: "550000000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
 ]);
 
 export const kintsugiRouteConfigs = createRouteConfigs("kintsugi", [
@@ -207,6 +215,13 @@ export const interlayTokensConfig: Record<
       decimals: 10,
       ed: "0",
       toRaw: () => ({ ForeignAsset: 3 }),
+    },
+    BNC: {
+      name: "BNC",
+      symbol: "BNC",
+      decimals: 12,
+      ed: "0",
+      toRaw: () => ({ ForeignAsset: 11 }),
     },
   },
   kintsugi: {


### PR DESCRIPTION
Changes:

- added BNC definition to Interlay adapter
- added routes between Bifrost Polkadot and Interlay
  - destination fees taken from recent XCM transactions and rounded up for provided estimate values
